### PR TITLE
PHP5 compatibility: Only starting with PHP7 keywords (such as 'unset') can be used as method names

### DIFF
--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -77,7 +77,7 @@ class QueryFactory implements QueryFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function unset($name)
+    public function remove($name)
     {
         unset($this->defaultParameters[$name]);
 

--- a/src/QueryFactoryInterface.php
+++ b/src/QueryFactoryInterface.php
@@ -52,7 +52,7 @@ interface QueryFactoryInterface
     public function has($name);
 
     /**
-     * Unsets the default parameter with the given name.
+     * Removes the default parameter with the given name.
      *
      * @param string $name
      *   The name of the parameter to unset.
@@ -60,7 +60,7 @@ interface QueryFactoryInterface
      * @return $this
      *   The updated query factory object.
      */
-    public function unset($name);
+    public function remove($name);
 
     /**
      * Returns a query object for the given Piwik API method.


### PR DESCRIPTION
Quoting from http://php.net/manual/en/reserved.keywords.php:

>  You cannot use any of the following words as constants, class names, function or method names