### PR TITLE
Handle 200 OK responses with an empty or non-json body.

### DIFF
--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -78,7 +78,7 @@ class QueryResult
         // but the body of the response will contain the string "error" in the
         // "result" parameter.
         // @see https://github.com/piwik/piwik/issues/7293
-        return $this->isObject() && $this->parameterExists('result') && $this->get('result') === 'error';
+        return !$this->isObject() || $this->parameterExists('result') && $this->get('result') === 'error';
     }
 
     /**


### PR DESCRIPTION
When an empty or non-json response is returned, the `QueryResult::hasError()` will return false, while the response is actually broken.