### PR TITLE
Provide support for both GET and POST queries.

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -104,10 +104,31 @@ class Query implements QueryInterface
     /**
      * {@inheritdoc}
      */
-    public function execute()
+    public function execute($method = 'GET')
     {
+        $method = strtoupper($method);
+        if (!in_array($method, ['GET', 'POST'])) {
+          throw new \InvalidArgumentException("Only 'GET' and 'POST' requests are allowed.");
+        }
+
         $this->prepareExecute();
-        $response = $this->httpClient->get($this->url, ['query' => $this->parameters]);
+        $response = $method === 'GET' ?
+          $this->httpClient->get($this->url, ['query' => $this->parameters]) :
+          $this->httpClient->post($this->url, ['form_params' => $this->parameters]);
         return new QueryResult($response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get() {
+      return $this->execute('GET');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function post() {
+      return $this->execute('POST');
     }
 }

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -57,8 +57,28 @@ interface QueryInterface
     /**
      * Executes the query.
      *
+     * @param string $method
+     *   The request method. Either 'GET' or 'POST'.
+     *
      * @return \Piwik\ReportingApi\QueryResult
      *   The query result.
      */
-    public function execute();
+    public function execute($method = 'GET');
+
+    /**
+     * Executes a get query.
+     *
+     * @return \Piwik\ReportingApi\QueryResult
+     *   The query result.
+     */
+    public function get();
+
+    /**
+     * Executes a post query.
+     *
+     * @return \Piwik\ReportingApi\QueryResult
+     *   The query result.
+     */
+    public function post();
+
 }


### PR DESCRIPTION
As in the title, provide support for GET and POST queries.
Currently, there is little control over the request itself as the query is usually some protected property and it is not accessible. This change can allow users to request both in a GET and a POST request.

The main idea behind this is that in GET requests, the url length is limited to 2048 characters. In POST request, the limit is the same but since the query parameters are passed in the stream, we don't care about the url length. GET requests limit the complexity of the query as PIWIK supports multi queries.